### PR TITLE
Fix networkEntity ID assignment to use GUID instead of map size

### DIFF
--- a/src/server/core/network-entities/network-entities.js
+++ b/src/server/core/network-entities/network-entities.js
@@ -6,6 +6,7 @@ import entityToData from './entity-parser.js';
 export default class NetworkEntities extends pc.EventHandler {
     index = new Map();
     entitiesInProcess = 0;
+    nextEntityId = 0;
 
     constructor(app) {
         super();
@@ -17,7 +18,9 @@ export default class NetworkEntities extends pc.EventHandler {
         script.entity.forEach((e) => {
             if (!e.networkEntity) return;
 
-            const id = `${pn.id}-${e.getGuid()}`;
+            const id = `${pn.id}-${this.nextEntityId}`;
+            this.nextEntityId++;
+            
             e.networkEntity.id = id;
             pn.redis.HSET('_route:networkEntity', id, pn.id);
 

--- a/src/server/core/network-entities/network-entities.js
+++ b/src/server/core/network-entities/network-entities.js
@@ -17,7 +17,7 @@ export default class NetworkEntities extends pc.EventHandler {
         script.entity.forEach((e) => {
             if (!e.networkEntity) return;
 
-            const id = `${pn.id}-${this.index.size}`;
+            const id = `${pn.id}-${e.getGuid()}`;
             e.networkEntity.id = id;
             pn.redis.HSET('_route:networkEntity', id, pn.id);
 


### PR DESCRIPTION
This pull request addresses a bug in the networkEntity ID assignment logic. Previously, the ID was generated based on the current size of the entities map. This approach led to ID collisions when entities were created and deleted in certain orders.

For example:

Created Player 1 with ID 21-0 (new map size: 1)
Created Enemy 1 with ID 21-1 (new map size: 2)
Created Player 2 with ID 21-2 (new map size: 3)
Destroyed Enemy 1 with ID 21-1 (map size reduced to 2)
Created Enemy 2 with ID 21-2
In this scenario, Enemy 2 and Player 2 ended up with the same networkEntity ID (21-2), which can lead to unexpected behavior and bugs.

To resolve this issue, the networkEntity ID assignment has been updated to use the entity's GUID instead of the map size. This ensures that each entity receives a unique and stable ID, regardless of the order in which entities are created or deleted.